### PR TITLE
Remove right lookahead

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ The accented counterpart of и is й and is represented by a separate letter, *j
 #### Soft Signs and Apostrophes
 The second change to National 2010 is that we try to restore soft signs and apostrophes:
 
-* Ukrayins'kyj (Український)
-* malen'kyj (маленький)
+* Ukrayins'kyj (Український), malen'kyj (маленький)
+* m'yaso (м'ясо), matir'yu (матір'ю)
 
 This feature is experimental and can be disabled by setting `apostrophes` to `false`.
 

--- a/shared/src/main/scala/translit/Language.scala
+++ b/shared/src/main/scala/translit/Language.scala
@@ -4,24 +4,24 @@ trait Language {
   /**
     * Convert Latin character `c` to Cyrillic
     *
-    * @param left  Left context prior to mapping
-    * @param c     Character to be mapped
-    * @param right Right context after mapping
+    * @param latin     Latin input, excluding next character
+    * @param cyrillic  Mapped Cyrillic letters
+    * @param append    Latin letter to be mapped next
+    *
     * @return (-n, r)  Replace last `n` characters by `r` with `left.length >= n`
-    *         ( 0, r)  Append character `r`
-    *         ( n, r)  Replace next `n` characters by `r` with `right.length >= n`
+    *         ( 0, r)  Append string `r`
     */
-  def latinToCyrillicOne(left: String = "",
-                         c: Char,
-                         right: String = ""): (Int, Char)
+  def latinToCyrillicIncremental(
+    latin: String, cyrillic: String, append: Char
+  ): (Int, String)
 
   def latinToCyrillic(text: String): String = {
     val result = new StringBuilder(text.length)
     var offset = 0
 
     while (offset < text.length) {
-      val (length, c) = latinToCyrillicOne(
-        text.take(offset), text(offset), text.drop(offset + 1))
+      val (length, c) = latinToCyrillicIncremental(
+        text.take(offset), result.mkString, text(offset))
       if (length < 0) result.setLength(result.length + length)
       result.append(c)
       offset += 1

--- a/shared/src/main/scala/translit/Noop.scala
+++ b/shared/src/main/scala/translit/Noop.scala
@@ -1,0 +1,8 @@
+package translit
+
+object Noop extends translit.Language {
+  override def latinToCyrillicIncremental(
+    latin: String, cyrillic: String, append: Char
+  ): (Int, String) = (0, append.toString)
+}
+

--- a/shared/src/main/scala/translit/Russian.scala
+++ b/shared/src/main/scala/translit/Russian.scala
@@ -53,29 +53,31 @@ object Russian extends Language {
     "shch" -> 'щ'
   )
 
-  def latinToCyrillicOne(left: String, c: Char, right: String): (Int, Char) = {
-    val text = left + c
+  override def latinToCyrillicIncremental(
+    latin: String, cyrillic: String, append: Char
+  ): (Int, String) = {
+    val text = latin + append
     val ofs = text.length
     if (ofs >= 4 &&
         fourGrams.contains(text.substring(ofs - 4, ofs).toLowerCase)) {
       val chars = text.substring(ofs - 4, ofs)
       val cyrillic = fourGrams(chars.toLowerCase)
-      (-2, restoreCaseFirst(chars, cyrillic))
+      (-2, restoreCaseFirst(chars, cyrillic).toString)
     } else if (ofs >= 3 &&
       triGrams.contains(text.substring(ofs - 3, ofs).toLowerCase)) {
       val chars = text.substring(ofs - 3, ofs)
       val cyrillic = triGrams(chars.toLowerCase)
-      (-2, restoreCaseFirst(chars, cyrillic))
+      (-2, restoreCaseFirst(chars, cyrillic).toString)
     } else if (ofs >= 2 &&
                biGrams.contains(text.substring(ofs - 2, ofs).toLowerCase)) {
       val chars = text.substring(ofs - 2, ofs)
       val cyrillic = biGrams(chars.toLowerCase)
-      (-1, restoreCaseFirst(chars, cyrillic))
+      (-1, restoreCaseFirst(chars, cyrillic).toString)
     } else if (uniGrams.contains(text(ofs - 1).toLower)) {
       val cyrillic = uniGrams(text(ofs - 1).toLower)
-      (0, if (text(ofs - 1).isUpper) cyrillic.toUpper else cyrillic)
+      (0, (if (text(ofs - 1).isUpper) cyrillic.toUpper else cyrillic).toString)
     } else {
-      (0, text(ofs - 1))
+      (0, text(ofs - 1).toString)
     }
   }
 }

--- a/shared/src/test/scala/translit/RussianSpec.scala
+++ b/shared/src/test/scala/translit/RussianSpec.scala
@@ -55,5 +55,7 @@ class RussianSpec extends FunSuite {
     assert(Russian.latinToCyrillic("s|hodit'") == "сходить")
     assert(Russian.latinToCyrillic("vy|uchil") == "выучил")
     assert(Russian.latinToCyrillic("krasivy|e") == "красивые")
+    assert(Russian.latinToCyrillic("nekotory|e") == "некоторые")
+    assert(Russian.latinToCyrillic("mezhdunarodny|e") == "международные")
   }
 }

--- a/shared/src/test/scala/translit/UkrainianSpec.scala
+++ b/shared/src/test/scala/translit/UkrainianSpec.scala
@@ -255,30 +255,42 @@ class UkrainianSpec extends FunSuite {
   test("сх") {
     assert(Ukrainian.latinToCyrillic("s|hyl'nist'") == "схильність")
     assert(Ukrainian.latinToCyrillic("s|hopyv") == "схопив")
+    assert(Ukrainian.latinToCyrillic("s|hodi") == "сході")
   }
 
-  test("Offsets") {
-    assert(Ukrainian.latinToCyrillicOne("", 's') == (0, 'с'))
-    assert(Ukrainian.latinToCyrillicOne("s" , 'h') == (-1, 'ш'))
-    assert(Ukrainian.latinToCyrillicOne("sh", 'c') == (0, 'ц'))
-    assert(Ukrainian.latinToCyrillicOne("shc", 'h') == (-2, 'щ'))
-    assert(Ukrainian.latinToCyrillicOne("yeshc", 'h') == (-2, 'щ'))
+  test("Incremental interface") {
+    assert(Ukrainian.latinToCyrillicIncremental("", "", 's') == (0, "с"))
+    assert(Ukrainian.latinToCyrillicIncremental("s", "" , 'h') == (-1, "ш"))
+    assert(Ukrainian.latinToCyrillicIncremental("sh", "", 'c') == (0, "ц"))
+    assert(Ukrainian.latinToCyrillicIncremental("shc", "", 'h') == (-2, "щ"))
+    assert(Ukrainian.latinToCyrillicIncremental("yeshc", "", 'h') == (-2, "щ"))
 
-    assert(Ukrainian.latinToCyrillicOne("", 'p') == (0, 'п'))
+    assert(Ukrainian.latinToCyrillicIncremental("", "", 'p') == (0, "п"))
 
-    assert(Ukrainian.latinToCyrillicOne("", 'y') == (0, 'и'))
-    assert(Ukrainian.latinToCyrillicOne("y", 'a') == (-1, 'я'))
-    assert(Ukrainian.latinToCyrillicOne("y", 'e') == (-1, 'є'))
+    assert(Ukrainian.latinToCyrillicIncremental("", "", 'y') == (0, "и"))
+    assert(Ukrainian.latinToCyrillicIncremental("y", "", 'a') == (-1, "я"))
+    assert(Ukrainian.latinToCyrillicIncremental("y", "", 'e') == (-1, "є"))
 
-    assert(Ukrainian.latinToCyrillicOne("", 'a') == (0, 'а'))
-    assert(Ukrainian.latinToCyrillicOne("ay", 'a') == (-1, 'я'))
+    assert(Ukrainian.latinToCyrillicIncremental("", "", 'a') == (0, "а"))
+    assert(Ukrainian.latinToCyrillicIncremental("ay", "", 'a') == (-1, "я"))
 
-    assert(Ukrainian.latinToCyrillicOne("yac", 'h') == (-1, 'ч'))
-    assert(Ukrainian.latinToCyrillicOne("v", 'y') == (0, 'и'))
-    assert(Ukrainian.latinToCyrillicOne("vyc", 'h') == (-1, 'ч'))
+    assert(Ukrainian.latinToCyrillicIncremental("yac", "", 'h') == (-1, "ч"))
+    assert(Ukrainian.latinToCyrillicIncremental("v", "", 'y') == (0, "и"))
+    assert(Ukrainian.latinToCyrillicIncremental("vyc", "", 'h') == (-1, "ч"))
 
-    assert(Ukrainian.latinToCyrillicOne("", 'z') == (0, 'з'))
-    assert(Ukrainian.latinToCyrillicOne("z", 'g') == (0, 'г'))
+    assert(Ukrainian.latinToCyrillicIncremental("", "", 'z') == (0, "з"))
+    assert(Ukrainian.latinToCyrillicIncremental("z", "", 'g') == (0, "г"))
+
+    assert(Ukrainian.latinToCyrillicIncremental("b", "б", '\'') == (0, "ь"))
+    assert(Ukrainian.latinToCyrillicIncremental("b'", "бь", 'y') == (0, "и"))
+    assert(Ukrainian.latinToCyrillicIncremental("b'y", "бьи", 'u') == (-2, "'ю"))
+
+    assert(Ukrainian.latinToCyrillicIncremental("kin", "кін", '\'') == (0, "ь"))
+    assert(Ukrainian.latinToCyrillicIncremental("blyz'k", "близьк", 'o') == (0, "о"))
+
+    assert(Ukrainian.latinToCyrillic("S'") == "Сь")
+    assert(Ukrainian.latinToCyrillic("S'o") == "Сьо")
+    assert(Ukrainian.latinToCyrillic("S'O") == "СЬО")
   }
 
   test("Convenience mappings") {


### PR DESCRIPTION
Allow the incremental interface to insert and update more than one
character. Give the function access to the previously mapped
Cyrillic letters such that replacement rules can be
context-dependent.

Further changes:
- Ukrainian: Fix the case of soft sign as early as possible
- Add `Noop` language