### PR TITLE
Implement Cyrillic to Latin conversion

### DIFF
--- a/shared/src/main/scala/translit/Helpers.scala
+++ b/shared/src/main/scala/translit/Helpers.scala
@@ -1,6 +1,9 @@
 package translit
 
 object Helpers {
+  def applyCase(str: String, isUpper: Boolean): String =
+    if (isUpper) str(0).toUpper + str.tail else str
+
   def restoreCaseAll(str: String, cyrillic: Char): Char =
     if (str.forall(_.isUpper)) cyrillic.toUpper else cyrillic
 

--- a/shared/src/main/scala/translit/Language.scala
+++ b/shared/src/main/scala/translit/Language.scala
@@ -15,6 +15,8 @@ trait Language {
     latin: String, cyrillic: String, append: Char
   ): (Int, String)
 
+  def cyrillicToLatinIncremental(cyrillic: String, letter: Char): (Int, String)
+
   def latinToCyrillic(text: String): String = {
     val result = new StringBuilder(text.length)
     var offset = 0
@@ -22,6 +24,21 @@ trait Language {
     while (offset < text.length) {
       val (length, c) = latinToCyrillicIncremental(
         text.take(offset), result.mkString, text(offset))
+      if (length < 0) result.setLength(result.length + length)
+      result.append(c)
+      offset += 1
+    }
+
+    result.mkString
+  }
+
+  def cyrillicToLatin(text: String): String = {
+    val result = new StringBuilder(text.length * 2)
+    var offset = 0
+
+    while (offset < text.length) {
+      val (length, c) = cyrillicToLatinIncremental(
+        text.take(offset), text(offset))
       if (length < 0) result.setLength(result.length + length)
       result.append(c)
       offset += 1

--- a/shared/src/main/scala/translit/Noop.scala
+++ b/shared/src/main/scala/translit/Noop.scala
@@ -4,5 +4,9 @@ object Noop extends translit.Language {
   override def latinToCyrillicIncremental(
     latin: String, cyrillic: String, append: Char
   ): (Int, String) = (0, append.toString)
+
+  override def cyrillicToLatinIncremental(
+   cyrillic: String, letter: Char
+  ): (Int, String) = (0, letter.toString)
 }
 

--- a/shared/src/main/scala/translit/Russian.scala
+++ b/shared/src/main/scala/translit/Russian.scala
@@ -29,9 +29,13 @@ object Russian extends Language {
     'w' -> 'ш',
     'x' -> 'ж',
     'y' -> 'ы',
-    'z' -> 'з',
+    'z' -> 'з'
+  )
+
+  // Infer case from previous character
+  val uniGramsSpecial = Map(
     '\'' -> 'ь',
-    '"' -> 'ъ'
+    '`' -> 'ъ'
   )
 
   val biGrams = Map(
@@ -42,9 +46,7 @@ object Russian extends Language {
     "zh" -> 'ж',
     "yo" -> 'ё',
     "yu" -> 'ю',
-
-    "y|" -> 'ы',  // красивые, выучил
-    "s|" -> 'с'   // сходить
+    "kh" -> 'х'
   )
 
   val triGrams = Map[String, Char]()
@@ -53,31 +55,98 @@ object Russian extends Language {
     "shch" -> 'щ'
   )
 
+  val uniGramsInv = uniGrams.toList.map(_.swap).toMap
+  val uniGramsSpecialInv = uniGramsSpecial.toList.map(_.swap).toMap
+  val biGramsInv = biGrams.toList.map(_.swap).toMap
+  val triGramsInv = triGrams.toList.map(_.swap).toMap
+  val fourGramsInv = fourGrams.toList.map(_.swap).toMap
+
+  // y after m/n/r/t/v will be rendered as ы unless it is iotated
+  val yLetters = Set("my", "ny", "ry", "ty", "vy")
+
+  // If the y is iotated, render it as я, ё or ю
+  val iotatedLetters = Set("ya", "yo", "yu")
+
   override def latinToCyrillicIncremental(
     latin: String, cyrillic: String, append: Char
   ): (Int, String) = {
     val text = latin + append
     val ofs = text.length
-    if (ofs >= 4 &&
-        fourGrams.contains(text.substring(ofs - 4, ofs).toLowerCase)) {
-      val chars = text.substring(ofs - 4, ofs)
-      val cyrillic = fourGrams(chars.toLowerCase)
-      (-2, restoreCaseFirst(chars, cyrillic).toString)
-    } else if (ofs >= 3 &&
-      triGrams.contains(text.substring(ofs - 3, ofs).toLowerCase)) {
-      val chars = text.substring(ofs - 3, ofs)
-      val cyrillic = triGrams(chars.toLowerCase)
-      (-2, restoreCaseFirst(chars, cyrillic).toString)
-    } else if (ofs >= 2 &&
-               biGrams.contains(text.substring(ofs - 2, ofs).toLowerCase)) {
-      val chars = text.substring(ofs - 2, ofs)
-      val cyrillic = biGrams(chars.toLowerCase)
-      (-1, restoreCaseFirst(chars, cyrillic).toString)
-    } else if (uniGrams.contains(text(ofs - 1).toLower)) {
-      val cyrillic = uniGrams(text(ofs - 1).toLower)
-      (0, (if (text(ofs - 1).isUpper) cyrillic.toUpper else cyrillic).toString)
-    } else {
-      (0, text(ofs - 1).toString)
+    val result =
+      if (ofs >= 4 &&
+          fourGrams.contains(text.substring(ofs - 4, ofs).toLowerCase)) {
+        val chars = text.substring(ofs - 4, ofs)
+        val cyrillic = fourGrams(chars.toLowerCase)
+        (-2, restoreCaseFirst(chars, cyrillic).toString)
+      } else if (ofs >= 3
+        && yLetters.contains(text.substring(ofs - 3, ofs - 1).toLowerCase)
+        && !iotatedLetters.contains(text.substring(ofs - 2, ofs).toLowerCase)
+      ) {
+        val cyrillic = uniGrams.getOrElse(text(ofs - 1).toLower, text(ofs - 1))
+        (0, (if (text(ofs - 1).isUpper) cyrillic.toUpper else cyrillic).toString)
+      } else if (ofs >= 3 &&
+                 triGrams.contains(text.substring(ofs - 3, ofs).toLowerCase)) {
+        val chars = text.substring(ofs - 3, ofs)
+        val cyrillic = triGrams(chars.toLowerCase)
+        (-2, restoreCaseFirst(chars, cyrillic).toString)
+      } else if (ofs >= 2 &&
+                 biGrams.contains(text.substring(ofs - 2, ofs).toLowerCase)) {
+        val chars = text.substring(ofs - 2, ofs)
+        val cyrillic = biGrams(chars.toLowerCase)
+        (-1, restoreCaseFirst(chars, cyrillic).toString)
+      } else if (uniGrams.contains(text(ofs - 1).toLower)) {
+        val cyrillic = uniGrams(text(ofs - 1).toLower)
+        (0, (if (text(ofs - 1).isUpper) cyrillic.toUpper else cyrillic).toString)
+      } else if (ofs >= 2 && uniGramsSpecial.contains(text(ofs - 1))) {
+        val result =
+          if (ofs >= 3 && text(ofs - 2).isUpper && text(ofs - 3).isUpper)
+            uniGramsSpecial(text(ofs - 1)).toUpper
+          else uniGramsSpecial(text(ofs - 1))
+        (0, result.toString)
+      } else {
+        (0, text(ofs - 1).toString)
+      }
+
+    if (ofs >= 3 && uniGramsSpecial.contains(text(ofs - 2))) {
+      val (l, r) = (text(ofs - 3), text(ofs - 1))
+      val letter = uniGramsSpecial(text(ofs - 2))
+      val replace = if (l.isUpper && r.isUpper) letter.toUpper else letter
+      val cyrillicOfs = cyrillic.length - 1
+
+      if (replace == cyrillic(cyrillicOfs)) result
+      else {
+        val updated = replace + cyrillic.substring(
+          cyrillicOfs + 1, cyrillic.length + result._1)
+        (-updated.length + result._1, updated + result._2)
+      }
+    } else result
+  }
+
+  private def toLatin(letter: Char): String = {
+    val isUpper = letter.isUpper
+    val letterLc = letter.toLower
+    fourGramsInv.get(letterLc).map(applyCase(_, isUpper))
+      .orElse(triGramsInv.get(letterLc).map(applyCase(_, isUpper)))
+      .orElse(biGramsInv.get(letterLc).map(applyCase(_, isUpper)))
+      .orElse(uniGramsInv.get(letterLc).map(x => applyCase(x.toString, isUpper)))
+      .orElse(uniGramsSpecialInv.get(letterLc).map(x => applyCase(x.toString, isUpper)))
+      .getOrElse(letter.toString)
+  }
+
+  override def cyrillicToLatinIncremental(
+    cyrillic: String, letter: Char
+  ): (Int, String) = {
+    val current = toLatin(letter)
+
+    val changeCase =
+      letter.isUpper &&
+      (cyrillic.length == 1 || cyrillic.lastOption.exists(_.isUpper))
+
+    if (!changeCase) (0, current)
+    else {
+      val mapped = toLatin(cyrillic.last)
+      val rest = mapped.tail
+      (-rest.length, rest.toUpperCase + current.toUpperCase)
     }
   }
 }

--- a/shared/src/test/scala/translit/RussianSpec.scala
+++ b/shared/src/test/scala/translit/RussianSpec.scala
@@ -3,7 +3,7 @@ package translit
 import org.scalatest.FunSuite
 
 class RussianSpec extends FunSuite {
-  val correctMapping = List(
+  val words = List(
     "Андрей" -> "Andrej",
     "Борис" -> "Boris",
     "Валера" -> "Valera",
@@ -22,11 +22,11 @@ class RussianSpec extends FunSuite {
     "овраг" -> "ovrag",
     "пьянство" -> "p'yanstvo",
     "роща" -> "roshcha",
-    "съел" -> "s\"el",
+    "съел" -> "s`el",
     "тележка" -> "telezhka",
-    "ухват" -> "uhvat",
+    "ухват" -> "ukhvat",
     "фольклор" -> "fol'klor",
-    "халтура" -> "haltura",
+    "халтура" -> "khaltura",
     "цвет" -> "cvet",
     "червь" -> "cherv'",
     "швея" -> "shveya",
@@ -36,9 +36,13 @@ class RussianSpec extends FunSuite {
     "ягненок" -> "yagnenok"
   )
 
-  correctMapping.foreach { case (cyrillic, latin) =>
-    test(s"$latin -> $cyrillic") {
+  words.foreach { case (cyrillic, latin) =>
+    test(s"$cyrillic <-> $latin") {
+      assert(Russian.cyrillicToLatin(cyrillic) == latin)
       assert(Russian.latinToCyrillic(latin) == cyrillic)
+
+      assert(Russian.cyrillicToLatin(cyrillic.toUpperCase) == latin.toUpperCase)
+      assert(Russian.latinToCyrillic(latin.toUpperCase) == cyrillic.toUpperCase)
     }
   }
 
@@ -46,16 +50,67 @@ class RussianSpec extends FunSuite {
     assert(Russian.latinToCyrillic("peshkom" ) == "пешком")
     assert(Russian.latinToCyrillic("zhizn'"  ) == "жизнь")
     assert(Russian.latinToCyrillic("shchetka") == "щетка")
-  }
-
-  test("Exceptions") {
-    assert(Russian.latinToCyrillic("vy") == "вы")
     assert(Russian.latinToCyrillic("rajon") == "район")
     assert(Russian.latinToCyrillic("schitayu") == "считаю")
-    assert(Russian.latinToCyrillic("s|hodit'") == "сходить")
-    assert(Russian.latinToCyrillic("vy|uchil") == "выучил")
-    assert(Russian.latinToCyrillic("krasivy|e") == "красивые")
-    assert(Russian.latinToCyrillic("nekotory|e") == "некоторые")
-    assert(Russian.latinToCyrillic("mezhdunarodny|e") == "международные")
+    assert(Russian.latinToCyrillic("proiskhodit'") == "происходить")
+    assert(Russian.latinToCyrillic("shirokoe") == "широкое")
+    assert(Russian.latinToCyrillic("carivshij") == "царивший")
+    assert(Russian.latinToCyrillic("polusharii") == "полушарии")
+  }
+
+  test("ye exceptions") {
+    // In this context, ye should not be mapped onto э
+    assert(Russian.latinToCyrillic("krasivye") == "красивые")
+    assert(Russian.latinToCyrillic("mezhdunarodnye") == "международные")
+    assert(Russian.latinToCyrillic("nekotorye") == "некоторые")
+    assert(Russian.latinToCyrillic("vyhodnye") == "выходные")
+  }
+
+  test("ya") {
+    assert(Russian.latinToCyrillic("altaryah") == "алтарях")
+    assert(Russian.latinToCyrillic("myagko") == "мягко")
+    assert(Russian.latinToCyrillic("ukrasheniya") == "украшения")
+  }
+
+  test("yu") {
+    assert(Russian.latinToCyrillic("molyu") == "молю")
+    assert(Russian.latinToCyrillic("nablyudaem") == "наблюдаем")
+  }
+
+  ignore("yu (exception)") {
+    // TODO Not covered yet
+    assert(Russian.latinToCyrillic("vyuchil") == "выучил")
+  }
+
+  ignore("ye") {
+    // TODO Foreign words conflict with some rules
+    assert(Russian.latinToCyrillic("ryeggi") == "рэгги")
+    assert(Russian.latinToCyrillic("myenskim") == "мэнским")
+    assert(Russian.latinToCyrillic("Gryemom") == "Грэмом")
+    assert(Russian.latinToCyrillic("Bryegg") == "Брэгг")
+    assert(Russian.latinToCyrillic("Revyu") == "Ревю")
+    assert(Russian.latinToCyrillic("Umyeo") == "Умэко")
+  }
+
+  test("Restore case") {
+    assert(Russian.latinToCyrillic("ZHIZN'") == "ЖИЗНЬ")
+    assert(Russian.latinToCyrillic("LOZH'") == "ЛОЖЬ")
+    assert(Russian.latinToCyrillic("FLAG`") == "ФЛАГЪ")
+    assert(Russian.latinToCyrillic("Ya.Shmid`") == "Я.Шмидъ")
+  }
+
+  test("Incremental transliteration") {
+    assert(Russian.latinToCyrillic("vy") == "вы")
+    assert(Russian.latinToCyrillic("S'") == "Сь")
+    assert(Russian.latinToCyrillic("S'o") == "Сьо")
+    assert(Russian.latinToCyrillic("S'O") == "СЬО")
+  }
+
+  test("Cyrillic to Latin") {
+    val latin = Russian.cyrillicToLatin("Фердинанд Теннис, описал два важнейших социологических абстрактных понятия")
+    assert(latin == "Ferdinand Tennis, opisal dva vazhnejshikh sociologicheskikh abstraktnykh ponyatiya")
+
+    val latin2 = Russian.cyrillicToLatin("Звезда расположена в главной части созвездия приблизительно посередине между Гаммой Лебедя и Альбирео.")
+    assert(latin2 == "Zvezda raspolozhena v glavnoj chasti sozvezdiya priblizitel'no poseredine mezhdu Gammoj Lebedya i Al'bireo.")
   }
 }

--- a/shared/src/test/scala/translit/UkrainianSpec.scala
+++ b/shared/src/test/scala/translit/UkrainianSpec.scala
@@ -3,7 +3,7 @@ package translit
 import org.scalatest.FunSuite
 
 class UkrainianSpec extends FunSuite {
-  val correctMapping = List(
+  val words = List(
     "Алушта" -> "Alushta",
     "Андрій" -> "Andrij",
     "Борщагівка" -> "Borshchagivka",
@@ -12,24 +12,24 @@ class UkrainianSpec extends FunSuite {
     "Володимир" -> "Volodymyr",
     "Гадяч" -> "Gadyach",
     "Богдан" -> "Bogdan",
-    "Згурський" -> "Zgurskyj",
+    "Згурський" -> "Zgurs'kyj",
     "Ґалаґан" -> "G'alag'an",
     "Ґорґани" -> "G'org'any",
-    "Донецьк" -> "Donetsk",
+    "Донецьк" -> "Donets'k",
     "Дмитро" -> "Dmytro",
     "Рівне" -> "Rivne",
     "Олег" -> "Oleg",
-    "Есмань" -> "Esman",
+    "Есмань" -> "Esman'",
     "Єнакієве" -> "Yenakiyeve",
     "Гаєвич" -> "Gayevych",
-    "Короп'є" -> "Koropye",
+    "Короп'є" -> "Korop'ye",
     "Житомир" -> "Zhytomyr",
     "Жанна" -> "Zhanna",
     "Жежелів" -> "Zhezheliv",
     "Закарпаття" -> "Zakarpattya",
     "Казимирчук" -> "Kazymyrchuk",
     "Медвин" -> "Medvyn",
-    "Михайленко" -> "Myhajlenko",
+    "Михайленко" -> "Mykhajlenko",
     "Іванків" -> "Ivankiv",
     "Іващенко" -> "Ivashchenko",
     "Їжакевич" -> "Yizhakevych",
@@ -50,24 +50,24 @@ class UkrainianSpec extends FunSuite {
     "Полтава" -> "Poltava",
     "Петро" -> "Petro",
     "Решетилівка" -> "Reshetylivka",
-    "Рибчинський" -> "Rybchynskyj",
+    "Рибчинський" -> "Rybchyns'kyj",
     "Суми" -> "Sumy",
     "Соломія" -> "Solomiya",
-    "Тернопіль" -> "Ternopil",
-    "Троць" -> "Trots",
+    "Тернопіль" -> "Ternopil'",
+    "Троць" -> "Trots'",
     "Ужгород" -> "Uzhgorod",
     "Уляна" -> "Ulyana",
     "Фастів" -> "Fastiv",
     "Філіпчук" -> "Filipchuk",
-    "Харків" -> "Harkiv",
-    "Христина" -> "Hrystyna",
+    "Харків" -> "Kharkiv",
+    "Христина" -> "Khrystyna",
     "Біла Церква" -> "Bila Tserkva",
     "Стеценко" -> "Stetsenko",
     "Чернівці" -> "Chernivtsi",
     "Шевченко" -> "Shevchenko",
     "Шостка" -> "Shostka",
-    "Кишеньки" -> "Kyshenky",
-    "Щербухи" -> "Shcherbuhy",
+    "Кишеньки" -> "Kyshen'ky",
+    "Щербухи" -> "Shcherbukhy",
     "Гоща" -> "Goshcha",
     "Гаращенко" -> "Garashchenko",
     "Юрій" -> "Yurij",
@@ -75,19 +75,17 @@ class UkrainianSpec extends FunSuite {
     "Яготин" -> "Yagotyn",
     "Ярошенко" -> "Yaroshenko",
     "Костянтин" -> "Kostyantyn",
-    "Знам'янка" -> "Znamyanka",
+    "Знам'янка" -> "Znam'yanka",
     "Феодосія" -> "Feodosiya"
   )
 
-  def removeApostropheAndSoftSign(str: String): String =
-    str
-      .replaceAll("ь", "")
-      .replaceAll("'", "")
+  words.foreach { case (cyrillic, latin) =>
+    test(s"$cyrillic <-> $latin") {
+      assert(Ukrainian.cyrillicToLatin(cyrillic) == latin)
+      assert(Ukrainian.latinToCyrillic(latin) == cyrillic)
 
-  correctMapping.foreach { case (cyrillic, latin) =>
-    test(s"$latin -> $cyrillic") {
-      assert(Ukrainian.latinToCyrillic(latin) ==
-        removeApostropheAndSoftSign(cyrillic))
+      assert(Ukrainian.cyrillicToLatin(cyrillic.toUpperCase) == latin.toUpperCase)
+      assert(Ukrainian.latinToCyrillic(latin.toUpperCase) == cyrillic.toUpperCase)
     }
   }
 
@@ -253,9 +251,9 @@ class UkrainianSpec extends FunSuite {
   }
 
   test("сх") {
-    assert(Ukrainian.latinToCyrillic("s|hyl'nist'") == "схильність")
-    assert(Ukrainian.latinToCyrillic("s|hopyv") == "схопив")
-    assert(Ukrainian.latinToCyrillic("s|hodi") == "сході")
+    assert(Ukrainian.latinToCyrillic("skhyl'nist'") == "схильність")
+    assert(Ukrainian.latinToCyrillic("skhopyv") == "схопив")
+    assert(Ukrainian.latinToCyrillic("skhodi") == "сході")
   }
 
   test("Incremental interface") {
@@ -295,5 +293,16 @@ class UkrainianSpec extends FunSuite {
 
   test("Convenience mappings") {
     assert(Ukrainian.latinToCyrillic("cqwx") == "цщшж")
+  }
+
+  test("Cyrillic to Latin") {
+    assert(Ukrainian.cyrillicToLatin("Щ") == "Shch")
+    assert(Ukrainian.cyrillicToLatin("ЩЕ") == "SHCHE")
+
+    assert(
+      Ukrainian.cyrillicToLatin("готовність, схильність суб'єкта до поведінкового акту, дії, вчинку, їх послідовності") ==
+      "gotovnist', skhyl'nist' sub'yekta do povedinkovogo aktu, diyi, vchynku, yikh poslidovnosti")
+
+    assert(Ukrainian.cyrillicToLatin("ІЯ") == "IYA")
   }
 }


### PR DESCRIPTION
In the process of implementing the reverse direction, several limitations were addressed in the rules. A lower error rate was observed on a small Wikipedia text corpus.

Notable changes include the removal of the vertical bar (|) for precedence. Instead, the bi-gram "kh" was introduced. Capital letters are now handled better. In Russian, ъ was mapped to ` since double quotes are commonly used in Slavic texts.

Closes #2.