### PR TITLE
Evaluate performance on 1M+ Wikipedia word corpora

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-.bloop/
-
 *.class
 *.log
 
@@ -17,4 +15,7 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
-.idea
+
+.bloop/
+/.idea/
+/.metals/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@
 
 translit-scala is a transliteration library for Scala and Scala.js. It implements transliteration rules for Slavic languages. It supports converting texts from the Latin to the Cyrillic alphabet and vice-versa.
 
+## Features
+* Supported languages
+	* Russian
+	* Ukrainian
+* Incremental transliteration
+* Transliterations reversible with an accuracy of 99.99%
+* Transliterations optimised for typing and reading
+	* Only letters from the US keyboard are used
+	* All common letters can be typed with a single keystroke
+	* Convenience shortcuts are provided
+* Cross-platform support (JVM, Scala.js)
+* Zero dependencies
+
 ## Compatibility
 | Back end   | Scala versions |
 |:-----------|:---------------|
@@ -19,14 +32,7 @@ libraryDependencies += "tech.sparse" %%% "translit-scala" % "0.1.1"  // JavaScri
 ## Examples
 ```scala
 translit.Ukrainian.latinToCyrillic("Kyyiv")  // Київ
-translit.Russian.latinToCyrillic("pal'ma")   // пальма
-```
-
-The transliteration to Cyrillic also restores soft signs (ь) and apostrophes ('):
-
-```scala
-translit.Ukrainian.latinToCyrillic("Mar'yana")  // Мар'яна
-translit.Ukrainian.latinToCyrillic("p'yat'")    // п'ять
+translit.Russian.latinToCyrillic("pal`ma")   // пальма
 ```
 
 ## Ukrainian
@@ -35,7 +41,7 @@ There have been several attempts to standardise transliteration rules. For examp
 * Ukrayins'kyy pravopys (BGN/PCGN 1965)
 * Ukrains'kyi pravopys (National 1996)
 * Ukrainskyi pravopys ([National 2010](http://zakon1.rada.gov.ua/laws/show/55-2010-%D0%BF))
-* Ukrayins'kyj pravopys (*translit-scala*)
+* Ukrayins\`kyj pravopys (*translit-scala*)
 
 Furthermore, there are language-specific transliterations, e.g. in German and French, that use the spelling conventions of the respective language (*sch* in German instead of *sh* in English).
 
@@ -50,7 +56,7 @@ Our transliteration was initially based on National 2010, but modified in the pr
 We decompose letters in their Latin transliteration more consistently than National 2010. The letter и always gets transcribed as *y*:
 
 * Volodymyr (Володимир)
-* blyz'ko (близько)
+* blyz\`ko (близько)
 
 The Latin letter *y* forms the phonetic basis of four letters (iotated vowels) in the Ukrainian alphabet: я, є, ї, ю. They get transliterated accordingly:
 
@@ -63,17 +69,15 @@ Unlike National 2010, we always use the same transliteration regardless of the p
 
 The accented counterpart of и is й and is represented by a separate letter, *j*.
 
-*Example:* Zgurs'kyj (Згурський)
+*Example:* Zgurs\`kyj (Згурський)
 
 #### Soft Signs and Apostrophes
-The second change to National 2010 is that we try to restore soft signs and apostrophes:
+The second change to National 2010 is that we retain soft signs (ь) and apostrophes ('):
 
-* Ukrayins'kyj (Український), malen'kyj (маленький)
+* Ukrayins\`kyj (Український), malen\`kyj (маленький)
 * m'yaso (м'ясо), matir'yu (матір'ю)
 
 In National 2010, *g* gets mapped to *ґ* which is phonetically accurate, though the letter *ґ* is fairly uncommon in Ukrainian. Therefore, we represent *ґ* by the bi-gram *g'*.
-
-This feature is experimental and can be disabled by setting `apostrophes` to `false`.
 
 #### Convenience mappings
 Another modification was to provide the following mappings:
@@ -95,7 +99,14 @@ Note that these mappings are phonetically inaccurate. However, using them still 
     * *q* and *w* are located next to each other; *ш* and *щ* characters are phonetically close
     * *z* and *x* are located next to each other; *з* and *ж* characters are phonetically close
 * *h* is mapped to *х* since it is a common letter, *kh* is only needed in case *h* is ambiguous
-	* An example is the word: схильність. The transliteration of *сх* corresponds to two separate letters *s* and *h*, which would map to *ш*. To prevent this, one can use the bi-gram *kh* instead to represent *х*. The full transliteration then looks as follows: *skhyl'nist*
+	* An example is the word: схильність. The transliteration of *сх* corresponds to two separate letters *s* and *h*, which would map to *ш*. To prevent this, one can use the bi-gram *kh* instead to represent *х*. The full transliteration then looks as follows: *skhyl\`nist*
+
+#### Escaping
+You can insert a backslash (\\) if a replacement rule should not be applied, for example:
+
+* stranstvy\e -> странствие
+* pidtry\annya -> підтриання
+* Bash\charshiyi -> Башчаршії
 
 ## Russian
 The Russian rules are similar to the Ukrainian ones.
@@ -103,9 +114,9 @@ The Russian rules are similar to the Ukrainian ones.
 Some differences are:
 
 * *i* corresponds to *и*, whereas *y* to *ы*
-* Russian distinguishes between soft and hard signs. It does not have apostrophes. The following mappings are used:
-  * Soft sign: *'* for ь
-  * Hard sign: *`* for ъ
+* Russian distinguishes between soft and hard signs. Apostrophes only appear in foreign names. The following mappings are used:
+  * Soft sign: *`* for ь
+  * Hard sign: *~* for ъ
 
 ### Mapping
 | Latin | Cyrillic |
@@ -136,8 +147,8 @@ Some differences are:
 | x     | ж        |
 | y     | ы        |
 | z     | з        |
-| '     | ь        |
-| \`    | ъ        |
+| \`    | ь        |
+| ~     | ъ        |
 | ch    | ч        |
 | sh    | ш        |
 | ya    | я        |
@@ -151,11 +162,11 @@ Some differences are:
 | Russian  | Transliterated |
 |----------|----------------|
 | Привет   | Privet         |
-| Съел     | S\`el          |
+| Съел     | S~el           |
 | Щётка    | Shchyotka      |
-| Льдина   | L'dina         |
-| красивые | krasivye       |
-| сходить  | skhodit'       |
+| Льдина   | L\`dina        |
+| красивые | krasivy\e      |
+| сходить  | skhodit\`      |
 
 ## Internals
 The replacement patterns are applied sequentially by traversing the input character-by-character. The functions `latinToCyrillicIncremental` and `cyrillicToLatinIncremental` take the left context which is needed by some rules, for example to determine the correct case of soft/hard signs. The result of the functions indicates the number of characters to remove on the right as well as their string replacement.
@@ -170,8 +181,16 @@ def cyrillicToLatinIncremental(
 ): (Int, String)
 ```
 
+## Performance
+The test suite evaluates whether transliterations are reversible. The accuracy is calculated on words extracted from Wikipedia article dumps for all supported languages. Words are transliterated to Latin and then back to Cyrillic. A word counts as correct if the result of the reversed transliteration matches the original.
+
+| Language  | Total     | Correct   | Accuracy |
+|-----------|-----------|-----------|----------|
+| Ukrainian | 1,811,772 | 1,811,661 | 99.99%   |
+| Russian   | 1,529,184 | 1,529,043 | 99.99%   |
+
 ## Credits
-The rules and examples were adapted from the following libraries:
+The rules and examples were adapted from the following libraries and websites:
 
 * [translit-english-ukrainian](https://github.com/MarkovSergii/translit-english-ukrainian)
 * [translit-ua](https://github.com/dchaplinsky/translit-ua)

--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,12 @@ lazy val translit = crossProject.in(file("."))
     /* Use io.js for faster compilation of test cases */
     scalaJSStage in Global := FastOptStage
   )
+  .jvmSettings(
+    libraryDependencies ++= Seq(
+      "com.github.pathikrit" %%% "better-files" % "3.8.0" % "test",
+      "org.scalaj" %%% "scalaj-http" % "2.4.2" % "test"
+    )
+  )
 
 lazy val js  = translit.js
 lazy val jvm = translit.jvm

--- a/build.toml
+++ b/build.toml
@@ -19,9 +19,19 @@ root    = "shared"
 sources = ["shared/src/main/scala"]
 targets = ["js", "jvm"]
 
+[module.translit.jvm]
+root = "jvm"
+
 [module.translit.test]
 sources   = ["shared/src/test/scala"]
 targets   = ["js", "jvm"]
 scalaDeps = [
   ["org.scalatest", "scalatest", "3.0.8"]
+]
+
+[module.translit.test.jvm]
+sources   = ["jvm/src/test/scala"]
+scalaDeps = [
+  ["com.github.pathikrit", "better-files", "3.8.0"],
+  ["org.scalaj", "scalaj-http", "2.4.2"]
 ]

--- a/jvm/src/test/scala/translit/CorpusSpec.scala
+++ b/jvm/src/test/scala/translit/CorpusSpec.scala
@@ -1,0 +1,67 @@
+package translit
+
+import java.nio.charset.Charset
+
+import better.files._
+import org.scalatest.FunSuite
+import scalaj.http.Http
+
+class CorpusSpec extends FunSuite {
+  def getDump(name: String): File = {
+    val file = File(s"/tmp/$name")
+    if (file.exists) file
+    else {
+      println(s"Downloading $name...")
+      val http = Http(s"http://builds.sparse.tech/wiki/$name").asBytes
+      assert(http.isSuccess)
+      file.writeByteArray(http.body)
+    }
+  }
+
+  def evaluate(dump: String, language: Language): (Long, Long) = {
+    val sentences = getDump(dump)
+
+    var correct = 0L
+    var total   = 0L
+
+    sentences.gzipInputStream().foreach { gzip =>
+      val words = gzip.lines(Charset.forName("UTF-8"))
+      val latin = (('a' to 'z') ++ ('A' to 'Z')).toSet
+
+      words.filter(!_.exists(latin.contains)).foreach { original =>
+        val latin    = language.cyrillicToLatin(original)
+        val cyrillic = language.latinToCyrillic(latin)
+        if (original == cyrillic) {
+          correct += 1
+        } else {
+          println(s"Mismatch: $original vs $cyrillic")
+        }
+
+        total += 1
+      }
+    }
+
+    (correct, total)
+  }
+
+  def check(perf: (Long, Long), expectedMinimum: Double): Unit = {
+    val (correct, total) = perf
+    val accuracy = correct.toDouble / total
+
+    println(s"Correct : $correct")
+    println(s"Total   : $total")
+    println(s"Accuracy: $accuracy")
+
+    assert(accuracy > expectedMinimum)
+  }
+
+  test("Russian") {
+    val perf = evaluate("tokens-ru-1710634.txt.gz", Russian)
+    check(perf, 0.999907)
+  }
+
+  test("Ukrainian") {
+    val perf = evaluate("tokens-uk-2000041.txt.gz", Ukrainian)
+    check(perf, 0.999938)
+  }
+}

--- a/shared/src/main/scala/translit/Ukrainian.scala
+++ b/shared/src/main/scala/translit/Ukrainian.scala
@@ -2,14 +2,11 @@ package translit
 
 import Helpers._
 
-/**
-  * @param apostrophes Enable context-dependent mapping of ' to apostrophes or
-  *                    soft signs
-  */
-class Ukrainian(apostrophes: Boolean) extends Language {
+object Ukrainian extends Language {
   val uniGrams = Map(
     'a' -> 'а',
     'b' -> 'б',
+    'c' -> 'ц',
     'd' -> 'д',
     'e' -> 'е',
     'f' -> 'ф',
@@ -32,7 +29,6 @@ class Ukrainian(apostrophes: Boolean) extends Language {
 
     // Mappings for more convenient typing. Allows us to cover every letter of
     // the Latin alphabet
-    'c' -> 'ц',
     'h' -> 'х',
     'q' -> 'щ',
     'w' -> 'ш',
@@ -49,7 +45,6 @@ class Ukrainian(apostrophes: Boolean) extends Language {
 
     "ch" -> 'ч',
     "sh" -> 'ш',
-    "ts" -> 'ц',
     "zh" -> 'ж',
 
     "kh" -> 'х'
@@ -61,42 +56,24 @@ class Ukrainian(apostrophes: Boolean) extends Language {
     "shch" -> 'щ'
   )
 
+  val escape = Map(
+    "ya" -> "иа",
+    "ye" -> "ие",
+    "yi" -> "иі",
+    "yu" -> "иу",
+    "g'" -> "г'",
+    "shch" -> "шч"
+  )
+  val escapeCharacter = '\\'
+
   val uniGramsInv = uniGrams.toList.map(_.swap).toMap
   val uniGramsSpecialInv = Map(
-    'ь' -> '\'',
+    'ь' -> '`',
     '\'' -> '\''
   )
   val biGramsInv = biGrams.toList.map(_.swap).toMap
   val triGramsInv = triGrams.toList.map(_.swap).toMap
   val fourGramsInv = fourGrams.toList.map(_.swap).toMap
-
-  val apostrophePatterns = Set(
-    ('b', "ya"),
-    ('b', "ye"),
-    ('b', "yu"),
-    ('d', "yu"),
-    ('d', "yi"),
-    ('f', "ya"),
-    ('f', "yu"),
-    ('m', "ya"),
-    ('m', "yu"),
-    ('n', "ye"),
-    ('n', "yu"),
-    ('p', "ya"),
-    ('p', "ye"),
-    ('r', "ya"),
-    ('r', "ye"),
-    ('r', "yu"),
-    ('r', "yi"),
-    ('s', "ye"),
-    ('t', "ya"),
-    ('v', "ya"),
-    ('v', "yi"),
-    ('z', "ya"),
-    ('z', "ye"),
-    ('z', "yu"),
-    ('z', "yi")
-  )
 
   override def latinToCyrillicIncremental(
     latin: String, cyrillic: String, append: Char
@@ -105,7 +82,11 @@ class Ukrainian(apostrophes: Boolean) extends Language {
     val ofs = text.length
 
     val result =
-      if (ofs >= 4 &&
+      if (ofs >= 5 && text.takeRight(5).toLowerCase == "sh\\ch") {
+        val cyrillic = 'ч'
+        val result = if (text(ofs - 1).isUpper) cyrillic.toUpper else cyrillic
+        (-2, result.toString)
+      } else if (ofs >= 4 &&
        fourGrams.contains(text.substring(ofs - 4, ofs).toLowerCase)
       ) {
         val chars    = text.substring(ofs - 4, ofs)
@@ -117,6 +98,14 @@ class Ukrainian(apostrophes: Boolean) extends Language {
         val chars    = text.substring(ofs - 3, ofs)
         val cyrillic = triGrams(chars.toLowerCase)
         (-1, restoreCaseAll(chars, cyrillic).toString)
+      } else if (ofs >= 3 &&
+        escape.keySet.contains(
+          (text(ofs - 3).toString + text(ofs - 1)).toLowerCase
+        ) && text(ofs - 2) == escapeCharacter
+      ) {
+        val cyrillic = uniGrams.getOrElse(text(ofs - 1).toLower, text(ofs - 1))
+        val result = if (text(ofs - 1).isUpper) cyrillic.toUpper else cyrillic
+        (-1, result.toString)
       } else if (ofs >= 2 &&
         biGrams.contains(text.substring(ofs - 2, ofs).toLowerCase)
       ) {
@@ -127,7 +116,7 @@ class Ukrainian(apostrophes: Boolean) extends Language {
         val cyrillic = uniGrams(text(ofs - 1).toLower)
         val result = if (text(ofs - 1).isUpper) cyrillic.toUpper else cyrillic
         (0, result.toString)
-      } else if (ofs >= 2 && text(ofs - 1) == '\'' && apostrophes) {
+      } else if (ofs >= 2 && text(ofs - 1) == '`') {
         val result =
           if (ofs >= 3 && text(ofs - 2).isUpper && text(ofs - 3).isUpper) "Ь"
           else "ь"
@@ -136,7 +125,7 @@ class Ukrainian(apostrophes: Boolean) extends Language {
         (0, text(ofs - 1).toString)
       }
 
-    if (ofs >= 3 && text(ofs - 2) == '\'' && apostrophes) {
+    if (ofs >= 3 && text(ofs - 2) == '`') {
       val (l, r) = (text(ofs - 3), text(ofs - 1))
       val replace = if (l.isUpper && r.isUpper) 'Ь' else 'ь'
       val softSign = cyrillic.length - 1
@@ -148,16 +137,13 @@ class Ukrainian(apostrophes: Boolean) extends Language {
           softSign + 1, cyrillic.length + result._1)
         (-updated.length + result._1, updated + result._2)
       }
-    } else if (ofs >= 4 && text(ofs - 3) == '\'' && apostrophes) {
+    } else if (ofs >= 4 && text(ofs - 3) == '`') {
       val (l, r) = (text(ofs - 4), text.substring(ofs - 2, ofs))
-      val letter =
-        if (apostrophePatterns.contains((l.toLower, r.toLowerCase))) '\''
-        else 'ь'
+      val letter = 'ь'
       val replace = if (l.isUpper && r.head.isUpper) letter.toUpper else letter
       val softSign = cyrillic.length - 2
 
-      if (cyrillic(softSign).toLower != 'ь' || replace == cyrillic(softSign))
-        result
+      if (replace == cyrillic(softSign)) result
       else {
         val updated = replace + cyrillic.substring(
           softSign + 1, cyrillic.length + result._1)
@@ -180,22 +166,26 @@ class Ukrainian(apostrophes: Boolean) extends Language {
   override def cyrillicToLatinIncremental(
     cyrillic: String, letter: Char
   ): (Int, String) = {
-    val current = toLatin(letter)
+    val current  = toLatin(letter)
+    val toEscape = cyrillic.lastOption
+      .map(_.toLower.toString + letter.toLower)
+      .exists(escape.values.toList.contains)
 
-    val changeCase =
-      letter.isUpper && {
-        val withoutApostrophes = cyrillic.filter(_ != '\'')
-        withoutApostrophes.length == 1 ||
-        withoutApostrophes.lastOption.exists(_.isUpper)
-      }
-
-    if (!changeCase) (0, current)
+    if (toEscape) (0, escapeCharacter + current)
     else {
-      val mapped = toLatin(cyrillic.last)
-      val rest = mapped.tail
-      (-rest.length, rest.toUpperCase + current.toUpperCase)
+      val changeCase =
+        letter.isUpper && {
+          val withoutApostrophes = cyrillic.filter(_ != '\'')
+          withoutApostrophes.length == 1 ||
+          withoutApostrophes.lastOption.exists(_.isUpper)
+        }
+
+      if (!changeCase) (0, current)
+      else {
+        val mapped = toLatin(cyrillic.last)
+        val rest   = mapped.tail
+        (-rest.length, rest.toUpperCase + current.toUpperCase)
+      }
     }
   }
 }
-
-object Ukrainian extends Ukrainian(apostrophes = true)

--- a/shared/src/test/scala/translit/RussianSpec.scala
+++ b/shared/src/test/scala/translit/RussianSpec.scala
@@ -7,33 +7,34 @@ class RussianSpec extends FunSuite {
     "Андрей" -> "Andrej",
     "Борис" -> "Boris",
     "Валера" -> "Valera",
-    "гвоздь" -> "gvozd'",
+    "гвоздь" -> "gvozd`",
     "днище" -> "dnishche",
     "Емеля" -> "Emelya",
     "ёлка" -> "yolka",
     "железо" -> "zhelezo",
-    "зыбь" -> "zyb'",
-    "Ильин" -> "Il'in",
+    "зыбь" -> "zyb`",
+    "Ильин" -> "Il`in",
     "Йемен" -> "Jemen",
     "киянка" -> "kiyanka",
     "лещ" -> "leshch",
-    "мышьяк" -> "mysh'yak",
+    "мышьяк" -> "mysh`yak",
     "Новгород" -> "Novgorod",
     "овраг" -> "ovrag",
-    "пьянство" -> "p'yanstvo",
+    "пьянство" -> "p`yanstvo",
     "роща" -> "roshcha",
-    "съел" -> "s`el",
+    "съел" -> "s~el",
     "тележка" -> "telezhka",
     "ухват" -> "ukhvat",
-    "фольклор" -> "fol'klor",
+    "фольклор" -> "fol`klor",
     "халтура" -> "khaltura",
     "цвет" -> "cvet",
-    "червь" -> "cherv'",
+    "червь" -> "cherv`",
     "швея" -> "shveya",
-    "щавель" -> "shchavel'",
+    "щавель" -> "shchavel`",
     "электровоз" -> "yelektrovoz",
     "юла" -> "yula",
-    "ягненок" -> "yagnenok"
+    "ягненок" -> "yagnenok",
+    "выучил" -> "vy\\uchil"
   )
 
   words.foreach { case (cyrillic, latin) =>
@@ -48,11 +49,11 @@ class RussianSpec extends FunSuite {
 
   test("Other words") {
     assert(Russian.latinToCyrillic("peshkom" ) == "пешком")
-    assert(Russian.latinToCyrillic("zhizn'"  ) == "жизнь")
+    assert(Russian.latinToCyrillic("zhizn`"  ) == "жизнь")
     assert(Russian.latinToCyrillic("shchetka") == "щетка")
     assert(Russian.latinToCyrillic("rajon") == "район")
     assert(Russian.latinToCyrillic("schitayu") == "считаю")
-    assert(Russian.latinToCyrillic("proiskhodit'") == "происходить")
+    assert(Russian.latinToCyrillic("proiskhodit`") == "происходить")
     assert(Russian.latinToCyrillic("shirokoe") == "широкое")
     assert(Russian.latinToCyrillic("carivshij") == "царивший")
     assert(Russian.latinToCyrillic("polusharii") == "полушарии")
@@ -60,10 +61,10 @@ class RussianSpec extends FunSuite {
 
   test("ye exceptions") {
     // In this context, ye should not be mapped onto э
-    assert(Russian.latinToCyrillic("krasivye") == "красивые")
-    assert(Russian.latinToCyrillic("mezhdunarodnye") == "международные")
-    assert(Russian.latinToCyrillic("nekotorye") == "некоторые")
-    assert(Russian.latinToCyrillic("vyhodnye") == "выходные")
+    assert(Russian.latinToCyrillic("krasivy\\e") == "красивые")
+    assert(Russian.latinToCyrillic("mezhdunarodny\\e") == "международные")
+    assert(Russian.latinToCyrillic("nekotory\\e") == "некоторые")
+    assert(Russian.latinToCyrillic("vyhodny\\e") == "выходные")
   }
 
   test("ya") {
@@ -77,33 +78,34 @@ class RussianSpec extends FunSuite {
     assert(Russian.latinToCyrillic("nablyudaem") == "наблюдаем")
   }
 
-  ignore("yu (exception)") {
-    // TODO Not covered yet
-    assert(Russian.latinToCyrillic("vyuchil") == "выучил")
+  test("Apostrophes") {
+    assert(Russian.latinToCyrillic("54'636") == "54'636")
+    assert(Russian.latinToCyrillic("d'Yespuar") == "д'Эспуар")
+    assert(Russian.latinToCyrillic("SSSR'78") == "СССР'78")
+    assert(Russian.latinToCyrillic("O'Kallagan") == "О'Каллаган")
   }
 
-  ignore("ye") {
-    // TODO Foreign words conflict with some rules
+  test("ye") {
     assert(Russian.latinToCyrillic("ryeggi") == "рэгги")
     assert(Russian.latinToCyrillic("myenskim") == "мэнским")
     assert(Russian.latinToCyrillic("Gryemom") == "Грэмом")
     assert(Russian.latinToCyrillic("Bryegg") == "Брэгг")
     assert(Russian.latinToCyrillic("Revyu") == "Ревю")
-    assert(Russian.latinToCyrillic("Umyeo") == "Умэко")
+    assert(Russian.latinToCyrillic("Umyeko") == "Умэко")
   }
 
   test("Restore case") {
-    assert(Russian.latinToCyrillic("ZHIZN'") == "ЖИЗНЬ")
-    assert(Russian.latinToCyrillic("LOZH'") == "ЛОЖЬ")
-    assert(Russian.latinToCyrillic("FLAG`") == "ФЛАГЪ")
-    assert(Russian.latinToCyrillic("Ya.Shmid`") == "Я.Шмидъ")
+    assert(Russian.latinToCyrillic("ZHIZN`") == "ЖИЗНЬ")
+    assert(Russian.latinToCyrillic("LOZH`") == "ЛОЖЬ")
+    assert(Russian.latinToCyrillic("FLAG~") == "ФЛАГЪ")
+    assert(Russian.latinToCyrillic("Ya.Shmid~") == "Я.Шмидъ")
   }
 
   test("Incremental transliteration") {
     assert(Russian.latinToCyrillic("vy") == "вы")
-    assert(Russian.latinToCyrillic("S'") == "Сь")
-    assert(Russian.latinToCyrillic("S'o") == "Сьо")
-    assert(Russian.latinToCyrillic("S'O") == "СЬО")
+    assert(Russian.latinToCyrillic("S`") == "Сь")
+    assert(Russian.latinToCyrillic("S`o") == "Сьо")
+    assert(Russian.latinToCyrillic("S`O") == "СЬО")
   }
 
   test("Cyrillic to Latin") {
@@ -111,6 +113,6 @@ class RussianSpec extends FunSuite {
     assert(latin == "Ferdinand Tennis, opisal dva vazhnejshikh sociologicheskikh abstraktnykh ponyatiya")
 
     val latin2 = Russian.cyrillicToLatin("Звезда расположена в главной части созвездия приблизительно посередине между Гаммой Лебедя и Альбирео.")
-    assert(latin2 == "Zvezda raspolozhena v glavnoj chasti sozvezdiya priblizitel'no poseredine mezhdu Gammoj Lebedya i Al'bireo.")
+    assert(latin2 == "Zvezda raspolozhena v glavnoj chasti sozvezdiya priblizitel`no poseredine mezhdu Gammoj Lebedya i Al`bireo.")
   }
 }

--- a/shared/src/test/scala/translit/UkrainianSpec.scala
+++ b/shared/src/test/scala/translit/UkrainianSpec.scala
@@ -8,18 +8,18 @@ class UkrainianSpec extends FunSuite {
     "Андрій" -> "Andrij",
     "Борщагівка" -> "Borshchagivka",
     "Борисенко" -> "Borysenko",
-    "Вінниця" -> "Vinnytsya",
+    "Вінниця" -> "Vinnycya",
     "Володимир" -> "Volodymyr",
     "Гадяч" -> "Gadyach",
     "Богдан" -> "Bogdan",
-    "Згурський" -> "Zgurs'kyj",
+    "Згурський" -> "Zgurs`kyj",
     "Ґалаґан" -> "G'alag'an",
     "Ґорґани" -> "G'org'any",
-    "Донецьк" -> "Donets'k",
+    "Донецьк" -> "Donec`k",
     "Дмитро" -> "Dmytro",
     "Рівне" -> "Rivne",
     "Олег" -> "Oleg",
-    "Есмань" -> "Esman'",
+    "Есмань" -> "Esman`",
     "Єнакієве" -> "Yenakiyeve",
     "Гаєвич" -> "Gayevych",
     "Короп'є" -> "Korop'ye",
@@ -50,23 +50,23 @@ class UkrainianSpec extends FunSuite {
     "Полтава" -> "Poltava",
     "Петро" -> "Petro",
     "Решетилівка" -> "Reshetylivka",
-    "Рибчинський" -> "Rybchyns'kyj",
+    "Рибчинський" -> "Rybchyns`kyj",
     "Суми" -> "Sumy",
     "Соломія" -> "Solomiya",
-    "Тернопіль" -> "Ternopil'",
-    "Троць" -> "Trots'",
+    "Тернопіль" -> "Ternopil`",
+    "Троць" -> "Troc`",
     "Ужгород" -> "Uzhgorod",
     "Уляна" -> "Ulyana",
     "Фастів" -> "Fastiv",
     "Філіпчук" -> "Filipchuk",
     "Харків" -> "Kharkiv",
     "Христина" -> "Khrystyna",
-    "Біла Церква" -> "Bila Tserkva",
-    "Стеценко" -> "Stetsenko",
-    "Чернівці" -> "Chernivtsi",
+    "Біла Церква" -> "Bila Cerkva",
+    "Стеценко" -> "Stecenko",
+    "Чернівці" -> "Chernivci",
     "Шевченко" -> "Shevchenko",
     "Шостка" -> "Shostka",
-    "Кишеньки" -> "Kyshen'ky",
+    "Кишеньки" -> "Kyshen`ky",
     "Щербухи" -> "Shcherbukhy",
     "Гоща" -> "Goshcha",
     "Гаращенко" -> "Garashchenko",
@@ -76,7 +76,10 @@ class UkrainianSpec extends FunSuite {
     "Ярошенко" -> "Yaroshenko",
     "Костянтин" -> "Kostyantyn",
     "Знам'янка" -> "Znam'yanka",
-    "Феодосія" -> "Feodosiya"
+    "Феодосія" -> "Feodosiya",
+    "странствие" -> "stranstvy\\e",
+    "підтриання" -> "pidtry\\annya",
+    "Башчаршії" -> "Bash\\charshiyi"
   )
 
   words.foreach { case (cyrillic, latin) =>
@@ -94,8 +97,8 @@ class UkrainianSpec extends FunSuite {
     assert(Ukrainian.latinToCyrillic("Kryyivka") == "Криївка")
     assert(Ukrainian.latinToCyrillic("Kategoriyi") == "Категорії")
 
-    assert(Ukrainian.latinToCyrillic("Stryjs'kyj park") == "Стрийський парк")
-    assert(Ukrainian.latinToCyrillic("Stryjs'ka") == "Стрийська")
+    assert(Ukrainian.latinToCyrillic("Stryjs`kyj park") == "Стрийський парк")
+    assert(Ukrainian.latinToCyrillic("Stryjs`ka") == "Стрийська")
     assert(Ukrainian.latinToCyrillic("kofeyin") == "кофеїн")
     assert(Ukrainian.latinToCyrillic("pryjnyatyh") == "прийнятих")
     assert(Ukrainian.latinToCyrillic("Staryj") == "Старий")
@@ -112,14 +115,14 @@ class UkrainianSpec extends FunSuite {
     assert(Ukrainian.latinToCyrillic("Myroslava") == "Мирослава")
     assert(Ukrainian.latinToCyrillic("MYROSLAVA") == "Мирослава".toUpperCase)
 
-    assert(Ukrainian.latinToCyrillic("Al'bert".toUpperCase) == "Альберт".toUpperCase)
-    assert(Ukrainian.latinToCyrillic("Zgurs'kyj".toUpperCase) == "Згурський".toUpperCase)
+    assert(Ukrainian.latinToCyrillic("Al`bert".toUpperCase) == "Альберт".toUpperCase)
+    assert(Ukrainian.latinToCyrillic("Zgurs`kyj".toUpperCase) == "Згурський".toUpperCase)
 
-    assert(Ukrainian.latinToCyrillic("sut'") == "суть")
-    assert(Ukrainian.latinToCyrillic("SUT'") == "суть".toUpperCase)
+    assert(Ukrainian.latinToCyrillic("sut`") == "суть")
+    assert(Ukrainian.latinToCyrillic("SUT`") == "суть".toUpperCase)
   }
 
-  test("Retain apostrophes") {
+  test("Apostrophes") {
     // From https://uk.wikipedia.org/wiki/%D0%90%D0%BF%D0%BE%D1%81%D1%82%D1%80%D0%BE%D1%84
     assert(Ukrainian.latinToCyrillic("Znam'yanka") == "Знам'янка")
     assert(Ukrainian.latinToCyrillic("sim'yu") == "сім'ю")
@@ -131,7 +134,7 @@ class UkrainianSpec extends FunSuite {
     assert(Ukrainian.latinToCyrillic("m'yaso") == "м'ясо")
     assert(Ukrainian.latinToCyrillic("rum'yanyj") == "рум'яний")
     assert(Ukrainian.latinToCyrillic("tim'ya") == "тім'я")
-    assert(Ukrainian.latinToCyrillic("meref'yans'kyj") == "мереф'янський")
+    assert(Ukrainian.latinToCyrillic("meref'yans`kyj") == "мереф'янський")
     assert(Ukrainian.latinToCyrillic("V'yacheslav") == "В'ячеслав")
     assert(Ukrainian.latinToCyrillic("Stef'yuk") == "Стеф'юк")
     assert(Ukrainian.latinToCyrillic("verb'ya") == "верб'я")
@@ -156,77 +159,76 @@ class UkrainianSpec extends FunSuite {
     assert(Ukrainian.latinToCyrillic("roz'yushyty") == "роз'юшити")
     assert(Ukrainian.latinToCyrillic("roz'yasnyty") == "роз'яснити")
     assert(Ukrainian.latinToCyrillic("dyt'yasla") == "дит'ясла")
-    assert(Ukrainian.latinToCyrillic("pan'yevropejs'kyj") == "пан'європейський")
+    assert(Ukrainian.latinToCyrillic("pan'yevropejs`kyj") == "пан'європейський")
     assert(Ukrainian.latinToCyrillic("piv'yabluka") == "пів'яблука")
-    assert(Ukrainian.latinToCyrillic("trans'yevropejs'kyj") == "транс'європейський")
+    assert(Ukrainian.latinToCyrillic("trans'yevropejs`kyj") == "транс'європейський")
     assert(Ukrainian.latinToCyrillic("im'ya") == "ім'я")
     assert(Ukrainian.latinToCyrillic("M'yakyj") == "М'який")
     assert(Ukrainian.latinToCyrillic("ob'yekt") == "об'єкт")
     assert(Ukrainian.latinToCyrillic("pam'yataty") == "пам'ятати")
     assert(Ukrainian.latinToCyrillic("ad'yutant") == "ад'ютант")
-    assert(Ukrainian.latinToCyrillic("in'yektsiya") == "ін'єкція")
+    assert(Ukrainian.latinToCyrillic("in'yekciya") == "ін'єкція")
     assert(Ukrainian.latinToCyrillic("kon'yunktyvit") == "кон'юнктивіт")
     assert(Ukrainian.latinToCyrillic("kon'yunktura") == "кон'юнктура")
     assert(Ukrainian.latinToCyrillic("Min'yust") == "Мін'юст")
   }
 
-  test("Restore soft signs") {
-    assert(Ukrainian.latinToCyrillic("Ukrayins'kyj") == "Український")
-    assert(Ukrainian.latinToCyrillic("Yul'yen") == "Юльєн")
-    assert(Ukrainian.latinToCyrillic("Sedertel'ye") == "Седертельє")
-    assert(Ukrainian.latinToCyrillic("Lil'yedal'") == "Лільєдаль")
-    assert(Ukrainian.latinToCyrillic("Ven'yan") == "Веньян")
-    assert(Ukrainian.latinToCyrillic("piran'ya") == "піранья")
-    assert(Ukrainian.latinToCyrillic("piran'yi") == "піраньї")
-    assert(Ukrainian.latinToCyrillic("port'ye") == "портьє")
-    assert(Ukrainian.latinToCyrillic("port'yera") == "портьєра")
-    assert(Ukrainian.latinToCyrillic("rel'yef") == "рельєф")
-    assert(Ukrainian.latinToCyrillic("batal'jon") == "батальйон")
-    assert(Ukrainian.latinToCyrillic("kan'jon") == "каньйон")
-    assert(Ukrainian.latinToCyrillic("montan'yar") == "монтаньяр")
-    assert(Ukrainian.latinToCyrillic("malen'kyj") == "маленький")
-    assert(Ukrainian.latinToCyrillic("vydayet'sya") == "видається")
-    assert(Ukrainian.latinToCyrillic("vydayet'sya") == "видається")
-    assert(Ukrainian.latinToCyrillic("pas'yans") == "пасьянс")
-    assert(Ukrainian.latinToCyrillic("kon'yak") == "коньяк")
-    assert(Ukrainian.latinToCyrillic("S'ogodni") == "Сьогодні")
+  test("Soft signs") {
+    assert(Ukrainian.latinToCyrillic("Ukrayins`kyj") == "Український")
+    assert(Ukrainian.latinToCyrillic("Yul`yen") == "Юльєн")
+    assert(Ukrainian.latinToCyrillic("Sedertel`ye") == "Седертельє")
+    assert(Ukrainian.latinToCyrillic("Lil`yedal`") == "Лільєдаль")
+    assert(Ukrainian.latinToCyrillic("Ven`yan") == "Веньян")
+    assert(Ukrainian.latinToCyrillic("piran`ya") == "піранья")
+    assert(Ukrainian.latinToCyrillic("piran`yi") == "піраньї")
+    assert(Ukrainian.latinToCyrillic("port`ye") == "портьє")
+    assert(Ukrainian.latinToCyrillic("port`yera") == "портьєра")
+    assert(Ukrainian.latinToCyrillic("rel`yef") == "рельєф")
+    assert(Ukrainian.latinToCyrillic("batal`jon") == "батальйон")
+    assert(Ukrainian.latinToCyrillic("kan`jon") == "каньйон")
+    assert(Ukrainian.latinToCyrillic("montan`yar") == "монтаньяр")
+    assert(Ukrainian.latinToCyrillic("malen`kyj") == "маленький")
+    assert(Ukrainian.latinToCyrillic("vydayet`sya") == "видається")
+    assert(Ukrainian.latinToCyrillic("vydayet`sya") == "видається")
+    assert(Ukrainian.latinToCyrillic("pas`yans") == "пасьянс")
+    assert(Ukrainian.latinToCyrillic("kon`yak") == "коньяк")
+    assert(Ukrainian.latinToCyrillic("S`ogodni") == "Сьогодні")
 
     // From https://uk.wikipedia.org/wiki/%D0%AC
-    assert(Ukrainian.latinToCyrillic("vis'") == "вісь")
-    assert(Ukrainian.latinToCyrillic("g'edz'") == "ґедзь")
-    assert(Ukrainian.latinToCyrillic("kin'") == "кінь")
-    assert(Ukrainian.latinToCyrillic("mid'") == "мідь")
-    assert(Ukrainian.latinToCyrillic("namoroz'") == "наморозь")
-    assert(Ukrainian.latinToCyrillic("palets'") == "палець")
-    assert(Ukrainian.latinToCyrillic("sut'") == "суть")
-    assert(Ukrainian.latinToCyrillic("shvets'") == "швець")
-    assert(Ukrainian.latinToCyrillic("blyz'ko") == "близько")
-    assert(Ukrainian.latinToCyrillic("vos'myj") == "восьмий")
-    assert(Ukrainian.latinToCyrillic("gan'ba") == "ганьба")
-    assert(Ukrainian.latinToCyrillic("Gryts'ko") == "Грицько")
-    assert(Ukrainian.latinToCyrillic("dyad'ko") == "дядько")
-    assert(Ukrainian.latinToCyrillic("kil'tse") == "кільце")
-    assert(Ukrainian.latinToCyrillic("molot'ba") == "молотьба")
-    assert(Ukrainian.latinToCyrillic("d'ogot'") == "дьоготь")
-    assert(Ukrainian.latinToCyrillic("dz'ob") == "дзьоб")
-    assert(Ukrainian.latinToCyrillic("l'on") == "льон")
-    assert(Ukrainian.latinToCyrillic("s'omyj") == "сьомий")
-    assert(Ukrainian.latinToCyrillic("tr'oh") == "трьох")
-    assert(Ukrainian.latinToCyrillic("t'ohkaty") == "тьохкати")
+    assert(Ukrainian.latinToCyrillic("vis`") == "вісь")
+    assert(Ukrainian.latinToCyrillic("g'edz`") == "ґедзь")
+    assert(Ukrainian.latinToCyrillic("kin`") == "кінь")
+    assert(Ukrainian.latinToCyrillic("mid`") == "мідь")
+    assert(Ukrainian.latinToCyrillic("namoroz`") == "наморозь")
+    assert(Ukrainian.latinToCyrillic("palec`") == "палець")
+    assert(Ukrainian.latinToCyrillic("sut`") == "суть")
+    assert(Ukrainian.latinToCyrillic("shvec`") == "швець")
+    assert(Ukrainian.latinToCyrillic("blyz`ko") == "близько")
+    assert(Ukrainian.latinToCyrillic("vos`myj") == "восьмий")
+    assert(Ukrainian.latinToCyrillic("gan`ba") == "ганьба")
+    assert(Ukrainian.latinToCyrillic("Gryc`ko") == "Грицько")
+    assert(Ukrainian.latinToCyrillic("dyad`ko") == "дядько")
+    assert(Ukrainian.latinToCyrillic("kil`ce") == "кільце")
+    assert(Ukrainian.latinToCyrillic("molot`ba") == "молотьба")
+    assert(Ukrainian.latinToCyrillic("d`ogot`") == "дьоготь")
+    assert(Ukrainian.latinToCyrillic("dz`ob") == "дзьоб")
+    assert(Ukrainian.latinToCyrillic("l`on") == "льон")
+    assert(Ukrainian.latinToCyrillic("s`omyj") == "сьомий")
+    assert(Ukrainian.latinToCyrillic("tr`oh") == "трьох")
+    assert(Ukrainian.latinToCyrillic("t`ohkaty") == "тьохкати")
 
-    // TODO Words where the soft sign cannot be restored
-    // assert(Ukrainian.latinToCyrillic("N'yurd") == "Ньюрд")
-    // assert(Ukrainian.latinToCyrillic("N'yuton") == "Ньютон")
-    // assert(Ukrainian.latinToCyrillic("Yil't'yaur") == "Їльтьяур")
-    // assert(Ukrainian.latinToCyrillic("Gran'yerde") == "Ґраньєрде")
-    // assert(Ukrainian.latinToCyrillic("brakon'yer") == "браконьєр")
-    // assert(Ukrainian.latinToCyrillic("buton'yerka") == "бутоньєрка")
-    // assert(Ukrainian.latinToCyrillic("vin'yetka") == "віньєтка")
-    // assert(Ukrainian.latinToCyrillic("dos'ye") == "досьє")
+    assert(Ukrainian.latinToCyrillic("N`yurd") == "Ньюрд")
+    assert(Ukrainian.latinToCyrillic("N`yuton") == "Ньютон")
+    assert(Ukrainian.latinToCyrillic("Yil`t`yaur") == "Їльтьяур")
+    assert(Ukrainian.latinToCyrillic("G'ran`yerde") == "Ґраньєрде")
+    assert(Ukrainian.latinToCyrillic("brakon`yer") == "браконьєр")
+    assert(Ukrainian.latinToCyrillic("buton`yerka") == "бутоньєрка")
+    assert(Ukrainian.latinToCyrillic("vin`yetka") == "віньєтка")
+    assert(Ukrainian.latinToCyrillic("dos`ye") == "досьє")
   }
 
   test("Disambiguate soft signs and apostrophes") {
-    assert(Ukrainian.latinToCyrillic("p'yat'") == "п'ять")
+    assert(Ukrainian.latinToCyrillic("p'yat`") == "п'ять")
   }
 
   test("Examples") {
@@ -238,8 +240,8 @@ class UkrainianSpec extends FunSuite {
     assert(Ukrainian.latinToCyrillic("teper") == "тепер")
     assert(Ukrainian.latinToCyrillic("shkolyar") == "школяр")
     assert(Ukrainian.latinToCyrillic("Harkiv") == "Харків")
-    assert(Ukrainian.latinToCyrillic("Al'bert Ejnshtejn") == "Альберт Ейнштейн")
-    assert(Ukrainian.latinToCyrillic("zdayut'sya") == "здаються")
+    assert(Ukrainian.latinToCyrillic("Al`bert Ejnshtejn") == "Альберт Ейнштейн")
+    assert(Ukrainian.latinToCyrillic("zdayut`sya") == "здаються")
     assert(Ukrainian.latinToCyrillic("postijnomu") == "постійному")
     assert(Ukrainian.latinToCyrillic("Jota") == "Йота")
     assert(Ukrainian.latinToCyrillic("Puzata Hata") == "Пузата Хата")
@@ -251,7 +253,7 @@ class UkrainianSpec extends FunSuite {
   }
 
   test("сх") {
-    assert(Ukrainian.latinToCyrillic("skhyl'nist'") == "схильність")
+    assert(Ukrainian.latinToCyrillic("skhyl`nist`") == "схильність")
     assert(Ukrainian.latinToCyrillic("skhopyv") == "схопив")
     assert(Ukrainian.latinToCyrillic("skhodi") == "сході")
   }
@@ -279,16 +281,16 @@ class UkrainianSpec extends FunSuite {
     assert(Ukrainian.latinToCyrillicIncremental("", "", 'z') == (0, "з"))
     assert(Ukrainian.latinToCyrillicIncremental("z", "", 'g') == (0, "г"))
 
-    assert(Ukrainian.latinToCyrillicIncremental("b", "б", '\'') == (0, "ь"))
-    assert(Ukrainian.latinToCyrillicIncremental("b'", "бь", 'y') == (0, "и"))
-    assert(Ukrainian.latinToCyrillicIncremental("b'y", "бьи", 'u') == (-2, "'ю"))
+    assert(Ukrainian.latinToCyrillicIncremental("b", "б", '`') == (0, "ь"))
+    assert(Ukrainian.latinToCyrillicIncremental("b`", "бь", 'y') == (0, "и"))
+    assert(Ukrainian.latinToCyrillicIncremental("b`y", "бьи", 'u') == (-1, "ю"))
 
-    assert(Ukrainian.latinToCyrillicIncremental("kin", "кін", '\'') == (0, "ь"))
-    assert(Ukrainian.latinToCyrillicIncremental("blyz'k", "близьк", 'o') == (0, "о"))
+    assert(Ukrainian.latinToCyrillicIncremental("kin", "кін", '`') == (0, "ь"))
+    assert(Ukrainian.latinToCyrillicIncremental("blyz`k", "близьк", 'o') == (0, "о"))
 
-    assert(Ukrainian.latinToCyrillic("S'") == "Сь")
-    assert(Ukrainian.latinToCyrillic("S'o") == "Сьо")
-    assert(Ukrainian.latinToCyrillic("S'O") == "СЬО")
+    assert(Ukrainian.latinToCyrillic("S`") == "Сь")
+    assert(Ukrainian.latinToCyrillic("S`o") == "Сьо")
+    assert(Ukrainian.latinToCyrillic("S`O") == "СЬО")
   }
 
   test("Convenience mappings") {
@@ -301,7 +303,7 @@ class UkrainianSpec extends FunSuite {
 
     assert(
       Ukrainian.cyrillicToLatin("готовність, схильність суб'єкта до поведінкового акту, дії, вчинку, їх послідовності") ==
-      "gotovnist', skhyl'nist' sub'yekta do povedinkovogo aktu, diyi, vchynku, yikh poslidovnosti")
+      "gotovnist`, skhyl`nist` sub'yekta do povedinkovogo aktu, diyi, vchynku, yikh poslidovnosti")
 
     assert(Ukrainian.cyrillicToLatin("ІЯ") == "IYA")
   }


### PR DESCRIPTION
- Improve accuracy of transliterations to 99.99%
- Support escaping to prevent rules from being applied
- Ukrainian: Remove `ts` mapping which led to false positives
- Ukrainian: Remove apostrophe detection
- Ukrainian, Russian: Use ` for soft sign
- Russian: Use `~` for hard sign

Closes #3.